### PR TITLE
Update bundler version

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A Renovate preset with common configuration for all Simplificator projects. The configuration currently applies the following:
 
-* The Dockerfile versions preset, useful when you need to install certain versions of tools in your Dockerfile, for example bndler. A usage example can be found [here](https://github.com/renovatebot/docker-renovate-full/blob/main/Dockerfile#L1-L2).
+* The Dockerfile versions preset, useful when you need to install certain versions of tools in your Dockerfile, for example bundler. A usage example can be found [here](https://github.com/renovatebot/docker-renovate-full/blob/main/Dockerfile#L1-L2).
 * Regex manager for [background services on Semaphore CI](https://docs.semaphoreci.com/ci-cd-environment/sem-service-managing-databases-and-services-on-linux/).
 * Regex manager to update the bundler version found in `Gemfile.lock`.
 * Group all non-major updates for packages with versions above 1.0.0.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 A Renovate preset with common configuration for all Simplificator projects. The configuration currently applies the following:
 
 * Regex manager for [background services on Semaphore CI](https://docs.semaphoreci.com/ci-cd-environment/sem-service-managing-databases-and-services-on-linux/).
+* Regex manager to update the bundler version found in `Gemfile.lock`.
 * Group all non-major updates for packages with versions above 1.0.0.
 * Group all patch updates for packages below version 1.0.0.
 * Apply the `bump` strategy for `npm`.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 A Renovate preset with common configuration for all Simplificator projects. The configuration currently applies the following:
 
+* The Dockerfile versions preset, useful when you need to install certain versions of tools in your Dockerfile, for example bndler. A usage example can be found [here](https://github.com/renovatebot/docker-renovate-full/blob/main/Dockerfile#L1-L2).
 * Regex manager for [background services on Semaphore CI](https://docs.semaphoreci.com/ci-cd-environment/sem-service-managing-databases-and-services-on-linux/).
 * Regex manager to update the bundler version found in `Gemfile.lock`.
 * Group all non-major updates for packages with versions above 1.0.0.

--- a/default.json
+++ b/default.json
@@ -14,6 +14,17 @@
       ],
       "datasourceTemplate": "docker",
       "registryUrlTemplate": "https://registry.semaphoreci.com"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "(^|/)Gemfile.lock$"
+      ],
+      "matchStrings": [
+        "BUNDLED WITH\\n[ ]+(?<currentValue>.*)(?:$|\\n)"
+      ],
+      "datasourceTemplate": "rubygems",
+      "depNameTemplate": "bundler"
     }
   ],
   "packageRules": [

--- a/default.json
+++ b/default.json
@@ -1,5 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "regexManagers:dockerfileVersions"
+  ],
   "labels": [
     "dependencies"
   ],


### PR DESCRIPTION
There are two common places in our projects where we can find bundler versions:

- In the `Gemfile.lock`
- In the `Dockerfile`, where we install bundler.

This PR:

- Adds a `regex` manager. that finds the current bundler version for a Gemfile and updates it. Usually, you do this by executing `bundle update --bundler`, but I do not expect any troubles with directly replacing the version, at least while the lockfile format does not change.
- Adds in the `regexManagers:dockerfileVersions` preset. Not sure if a preset can extend another preset, will have to see.