### PR TITLE
Create separate group for non-patch Rails updates

### DIFF
--- a/.github/workflows/renovate-config-validation.yml
+++ b/.github/workflows/renovate-config-validation.yml
@@ -15,3 +15,5 @@ jobs:
 
       - name: Validate
         uses: suzuki-shunsuke/github-action-renovate-config-validator@v0.1.3
+        with:
+          config_file_path: "default.json"

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A Renovate preset with common configuration for all Simplificator projects. The 
 * Regex manager to update the bundler version found in `Gemfile.lock`.
 * Group all non-major updates for packages with versions above 1.0.0.
 * Group all patch updates for packages below version 1.0.0.
+* Create a separate group for all non-patch Rails updates.
 * Apply the `bump` strategy for `npm`.
 * Apply the `update-lockfile` strategy for `bundler`.
 * Apply the `pin` strategy for `mix`.

--- a/default.json
+++ b/default.json
@@ -55,6 +55,20 @@
       ]
     },
     {
+      "matchPackageNames": [
+        "rails"
+      ],
+      "matchPackagePatterns": [
+        "^@rails/"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ],
+      "commitMessageAction": "Apply",
+      "groupName": "all non-patch Rails updates"
+    },
+    {
       "matchManagers": [
         "npm"
       ],


### PR DESCRIPTION
As a reaction to the Rails 7.1 release today:
https://rubyonrails.org/2023/10/5/Rails-7-1-0-has-been-released

I tried it out on a personal project and the PR / commit message looks as expected: https://github.com/andyundso/anno1800-goods-tracker/pull/227