### PR TITLE
Create a separate group for factory_bot updates

### DIFF
--- a/default.json
+++ b/default.json
@@ -69,6 +69,12 @@
       "groupName": "all non-patch Rails updates"
     },
     {
+      "groupName": "all factory_bot updates",
+      "matchPackagePatterns": [
+        "^factory_bot"
+      ]
+    },
+    {
       "matchManagers": [
         "npm"
       ],


### PR DESCRIPTION
There is an issue in the newest release with traits: https://github.com/thoughtbot/factory_bot_rails/issues/431 https://github.com/thoughtbot/factory_bot/pull/1600

as we use this library in many projects, I suggest to add a separate group for it in the preset until the bug is fixed, so we can continue to merge the non-major dependencies for this week.