### PR TITLE
Remove `factory_bot` group

### DIFF
--- a/default.json
+++ b/default.json
@@ -69,12 +69,6 @@
       "groupName": "all non-patch Rails updates"
     },
     {
-      "groupName": "all factory_bot updates",
-      "matchPackagePatterns": [
-        "^factory_bot"
-      ]
-    },
-    {
       "groupName": "all non-patch vite updates",
       "matchUpdateTypes": ["major", "minor"],
       "matchPackagePatterns": ["^vite"]


### PR DESCRIPTION
I noted that pipelines pass again for internal projects which use `factory_bot`. It seems that the new release v6.4.2 fixed the issues that were introduced with v6.3.0, so I think we can safely remove the separate group from our preset.