### PR TITLE
Make separate group for all Ruby updates

### DIFF
--- a/default.json
+++ b/default.json
@@ -70,8 +70,19 @@
     },
     {
       "groupName": "all non-patch vite updates",
-      "matchUpdateTypes": ["major", "minor"],
-      "matchPackagePatterns": ["^vite"]
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ],
+      "matchPackagePatterns": [
+        "^vite"
+      ]
+    },
+    {
+      "groupName": "all Ruby updates",
+      "matchPackagePatterns": [
+        "^ruby"
+      ]
     },
     {
       "matchManagers": [


### PR DESCRIPTION
With Ruby, a new minor release usually also needs further inspection to check if something has to be adapted in the code.

However, Renovate also fetches its Ruby updates from https://github.com/containerbase/ruby-prebuild, which is sometimes not immediately ready with the new version upon release. To avoid failing pipelines with the "all non-major version" group, extracting the Ruby updates should be the best method.