### PR TITLE
Separare group for major Turbo Rails upgrades

### DIFF
--- a/default.json
+++ b/default.json
@@ -85,6 +85,15 @@
       ]
     },
     {
+      "groupName": "all major turbo-rails upgrades",
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "matchPackagePatterns": [
+        "turbo-rails$"
+      ]
+    },
+    {
       "matchManagers": [
         "npm"
       ],


### PR DESCRIPTION
`@hotwired/turbo-rails` v8 has been released, alongside a new version of the `turbo-rails` gem. These updates should be applied together.